### PR TITLE
Collections Migration mode support

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -27,8 +27,8 @@ const FileDifferDir = "fileDiff"
 const MutationDifferDir = "mutationDiff"
 const DiffKeysFileName = "diffKeys"
 const DiffDetailsFileName = "diffDetails"
+const DiffKeysSrcMigrationHintSuffix = "hint"
 const MutationDiffFileName = "mutationDiffDetails"
-const MutationBodyDiffFileName = "mutationBodyDiffDetails"
 const MutationDiffColIdMapping = "mutationDiffColIdMapping"
 const DiffErrorKeysFileName = "diffKeysWithError"
 const StatsReportInterval = 5
@@ -65,7 +65,15 @@ const CheckpointInterval = 600
 //  datatype - 2 byte
 //  hash     - 64 bytes
 //  collectionId - 4 bytes
+//  migrationFilterLen - 2 bytes
+//  (variable) - each filterID is 2 bytes
 const BodyLength = 104
+const KeyLenVariable = 2
+const MigrationFilterLen = 2
+
+func GetFixedSizeMutationLen(keyLen int, colMigrationFilterMatched []uint8) int {
+	return KeyLenVariable + keyLen + BodyLength + MigrationFilterLen + len(colMigrationFilterMatched)*2
+}
 
 var VersionForRBACSupport = []int{5, 0}
 

--- a/dcp/CheckpointManager.go
+++ b/dcp/CheckpointManager.go
@@ -317,10 +317,10 @@ func (cm *CheckpointManager) getVbuuidsAndHighSeqnos() error {
 
 	if cm.dcpDriver.completeBySeqno {
 		cm.endSeqnoMap = endSeqnoMap
-		// For end seqno 0's, mark them as completed
+		// For end Seqno 0's, mark them as completed
 		for vb, seqno := range endSeqnoMap {
 			if seqno == 0 {
-				cm.dcpDriver.handleVbucketCompletion(vb, nil, "end seqno reached")
+				cm.dcpDriver.handleVbucketCompletion(vb, nil, "end Seqno reached")
 			}
 		}
 	} else {
@@ -374,7 +374,7 @@ func (cm *CheckpointManager) setStartVBTS() error {
 				cm.startVBTS[vbno].NoNeedToStartDcpStream = true
 			}
 
-			// update start seqno as that in checkpoint doc
+			// update start Seqno as that in checkpoint doc
 			cm.seqnoMap[vbno].setSeqno(checkpoint.Seqno)
 			sum += checkpoint.Seqno
 			totalFiltered += checkpoint.FilteredCnt
@@ -520,24 +520,24 @@ func (cm *CheckpointManager) RecordFilterEvent(vbno uint16, filterResult base.Fi
 }
 
 // no need to lock seqoMap since
-// 1. MutationProcessedEvent on a vbno are serialized
+// 1. MutationProcessedEvent on a Vbno are serialized
 // 2. checkpointManager reads seqnoMap when it saves checkpoints.
 //    This is done after all DcpHandlers are stopped and MutationProcessedEvent cease to happen
 func (cm *CheckpointManager) HandleMutationEvent(mut *Mutation, filterResult base.FilterResultType) bool {
 	if cm.dcpDriver.completeBySeqno {
-		endSeqno := cm.endSeqnoMap[mut.vbno]
-		if mut.seqno >= endSeqno {
-			cm.dcpDriver.handleVbucketCompletion(mut.vbno, nil, "end seqno reached")
+		endSeqno := cm.endSeqnoMap[mut.Vbno]
+		if mut.Seqno >= endSeqno {
+			cm.dcpDriver.handleVbucketCompletion(mut.Vbno, nil, "end Seqno reached")
 		}
-		if mut.seqno <= endSeqno {
-			cm.seqnoMap[mut.vbno].setSeqno(mut.seqno)
-			return cm.RecordFilterEvent(mut.vbno, filterResult)
+		if mut.Seqno <= endSeqno {
+			cm.seqnoMap[mut.Vbno].setSeqno(mut.Seqno)
+			return cm.RecordFilterEvent(mut.Vbno, filterResult)
 		} else {
 			return false
 		}
 	} else {
-		cm.seqnoMap[mut.vbno].setSeqno(mut.seqno)
-		return cm.RecordFilterEvent(mut.vbno, filterResult)
+		cm.seqnoMap[mut.Vbno].setSeqno(mut.Seqno)
+		return cm.RecordFilterEvent(mut.Vbno, filterResult)
 	}
 }
 

--- a/dcp/GocbcoreDCPAgent.go
+++ b/dcp/GocbcoreDCPAgent.go
@@ -43,7 +43,7 @@ type DCPFeedParams struct {
 	IncludeXAttrs bool `json:"includeXAttrs,omitempty"`
 
 	// Used to specify whether the applications are not interested
-	// in receiving the value for mutations in a dcp stream.
+	// in receiving the Value for mutations in a dcp stream.
 	NoValue bool `json:"noValue,omitempty"`
 
 	// Scope within the bucket to stream data from.

--- a/runDiffer.sh
+++ b/runDiffer.sh
@@ -183,5 +183,6 @@ function ctrl_c() {
 
 tail -f $differLogFileName &
 waitForBgJobs $bgPid
+killBgTail
 
 unset CBAUTH_REVRPC_URL


### PR DESCRIPTION
1. We need to translate the migration rules into ordered list of filter strings.
2. Once the filter strings are ordered, we will work off of the index of each filter string. This means if a mutation passes the first filter, we'll mark it passed filter 0. This will simplify the communications between fileDiffer and mutationDiffer.
3. We then need to trigger DCP ingestion from just the source default collection the target collections that the rules have specified. 
4. For ingestion, while the mutation is received from the source DCP, it needs to pass through each ordered filter one by one, and record which ones of the filter it passed. This will need to be output into the binary file for the differ to ingest.
5. The fileDiffer will need to ingest the new format of the binary files. Once it retrieves which filter(s) it passes, it needs to make sure that the target collection(s) do contain the same document. The fileDiffer will find docs missing from the target only and not from the source to cover the case of iterative migration. It will then output the keys and mapping (hint) for the mutationDiffer to ingest.
6. The mutationDiffer will read the files produced by fileDiffer and grab the corresponding docs that need diffing, and perform the diff. Not much has changed here except for the reading the hint map from step 5.
