### PR TITLE
Update goxdcr and gomemcached dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ deps:
 	$(GOGET) github.com/couchbase/gocb
 	$(GOGET) github.com/couchbase/gocb/v2
 	$(GOGET) github.com/couchbaselabs/gojsonsm@v1.0.0
-	$(GOGET) github.com/couchbase/goxdcr@v7.1.0-1003_2
+	$(GOGET) github.com/couchbase/goxdcr@v8.0.0-1168
 	$(GOGET) github.com/rcrowley/go-metrics
 	$(GOGET) github.com/couchbase/cbauth
-	$(GOGET) github.com/couchbase/gomemcached@v0.1.3
+	$(GOGET) github.com/couchbase/gomemcached@v0.2.1
 	$(GOGET) github.com/couchbase/go-couchbase@v0.1.0
 	$(GOGET) github.com/couchbase/goutils@v0.1.0
 	$(GOGET) golang.org/x/crypto

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ It won’t affect the accuracy of the result, but it’ll cause differ to run lo
 
 ## Known Limitations
 1. No dynamic topology change support. If VBs are moved during runtime, the tool does not handle it well.
+2. Strict security level is not supported at this time.
 
 ## License
 

--- a/dcp/DcpClient.go
+++ b/dcp/DcpClient.go
@@ -217,7 +217,7 @@ func initializeClusterWithSecurity(dcpDriver *DcpDriver) (*gocb.Cluster, error) 
 	clusterOpts := gocb.ClusterOptions{}
 
 	if dcpDriver.ref.HttpAuthMech() == xdcrBase.HttpAuthMechHttps {
-		tlsCert := tls.Certificate{Certificate: [][]byte{dcpDriver.ref.Certificate()}}
+		tlsCert := tls.Certificate{Certificate: [][]byte{dcpDriver.ref.Certificates()}}
 		clusterOpts.Authenticator = gocb.CertificateAuthenticator{ClientCertificate: &tlsCert}
 	} else {
 		clusterOpts.Authenticator = gocb.PasswordAuthenticator{
@@ -260,7 +260,7 @@ func initializeBucketWithSecurity(dcpDriver *DcpDriver, kvVbMap map[string][]uin
 	if dcpDriver.ref.HttpAuthMech() == xdcrBase.HttpAuthMechHttps {
 		auth = &base.CertificateAuth{
 			PasswordAuth:     pwAuth,
-			CertificateBytes: dcpDriver.ref.Certificate(),
+			CertificateBytes: dcpDriver.ref.Certificates(),
 		}
 
 		sslPort, found := kvSSLPortMap[bucketConnStr]
@@ -419,7 +419,7 @@ func initializeSSLPorts(dcpDriver *DcpDriver) (map[string]uint16, error) {
 	}
 	// By default the url passed in should be ns_server
 	kvSSLPortMap, err = dcpDriver.utils.GetMemcachedSSLPortMap(connStr, dcpDriver.ref.UserName(),
-		dcpDriver.ref.Password(), dcpDriver.ref.HttpAuthMech(), dcpDriver.ref.Certificate(),
+		dcpDriver.ref.Password(), dcpDriver.ref.HttpAuthMech(), dcpDriver.ref.Certificates(),
 		dcpDriver.ref.SANInCertificate(), dcpDriver.ref.ClientCertificate(), dcpDriver.ref.ClientKey(),
 		dcpDriver.bucketName, dcpDriver.logger, false)
 
@@ -437,7 +437,7 @@ func initializeKVVBMap(dcpDriver *DcpDriver) (map[string][]uint16, error) {
 	}
 
 	_, _, _, _, _, kvVbMap, err = dcpDriver.utils.BucketValidationInfo(connStr, dcpDriver.bucketName, dcpDriver.ref.UserName(),
-		dcpDriver.ref.Password(), dcpDriver.ref.HttpAuthMech(), dcpDriver.ref.Certificate(),
+		dcpDriver.ref.Password(), dcpDriver.ref.HttpAuthMech(), dcpDriver.ref.Certificates(),
 		dcpDriver.ref.SANInCertificate(), dcpDriver.ref.ClientCertificate(), dcpDriver.ref.ClientKey(),
 		dcpDriver.logger)
 

--- a/differ/mutationDiffer.go
+++ b/differ/mutationDiffer.go
@@ -1092,7 +1092,7 @@ func (d *MutationDiffer) openBucket(bucketName string, reference *metadata.Remot
 	if reference.HttpAuthMech() == xdcrBase.HttpAuthMechHttps {
 		auth = &base.CertificateAuth{
 			PasswordAuth:     pwAuth,
-			CertificateBytes: reference.Certificate(),
+			CertificateBytes: reference.Certificates(),
 		}
 		err = d.initializeKvSSLMap(source)
 		if err != nil {
@@ -1149,12 +1149,12 @@ func (d *MutationDiffer) initializeKvSSLMap(source bool) error {
 
 	if source {
 		d.srcKvSSLPortMap, err = d.utils.GetMemcachedSSLPortMap(connStr, d.sourceReference.UserName(),
-			d.sourceReference.Password(), d.sourceReference.HttpAuthMech(), d.sourceReference.Certificate(),
+			d.sourceReference.Password(), d.sourceReference.HttpAuthMech(), d.sourceReference.Certificates(),
 			d.sourceReference.SANInCertificate(), d.sourceReference.ClientCertificate(), d.sourceReference.ClientKey(),
 			d.sourceBucketName, d.logger, false)
 	} else {
 		d.tgtKvSSLPortMap, err = d.utils.GetMemcachedSSLPortMap(connStr, d.targetReference.UserName(),
-			d.targetReference.Password(), d.targetReference.HttpAuthMech(), d.targetReference.Certificate(),
+			d.targetReference.Password(), d.targetReference.HttpAuthMech(), d.targetReference.Certificates(),
 			d.targetReference.SANInCertificate(), d.targetReference.ClientCertificate(), d.targetReference.ClientKey(),
 			d.targetBucketName, d.logger, false)
 	}
@@ -1175,12 +1175,12 @@ func (d *MutationDiffer) initializeKVVBMap(source bool) error {
 
 	if source {
 		_, _, _, _, _, d.srcKvVbMap, err = d.utils.BucketValidationInfo(connStr, d.sourceBucketName, d.sourceReference.UserName(),
-			d.sourceReference.Password(), d.sourceReference.HttpAuthMech(), d.sourceReference.Certificate(),
+			d.sourceReference.Password(), d.sourceReference.HttpAuthMech(), d.sourceReference.Certificates(),
 			d.sourceReference.SANInCertificate(), d.sourceReference.ClientCertificate(), d.sourceReference.ClientKey(),
 			d.logger)
 	} else {
 		_, _, _, _, _, d.tgtKvVbMap, err = d.utils.BucketValidationInfo(connStr, d.targetBucketName, d.targetReference.UserName(),
-			d.targetReference.Password(), d.targetReference.HttpAuthMech(), d.targetReference.Certificate(),
+			d.targetReference.Password(), d.targetReference.HttpAuthMech(), d.targetReference.Certificates(),
 			d.targetReference.SANInCertificate(), d.targetReference.ClientCertificate(), d.targetReference.ClientKey(),
 			d.logger)
 	}


### PR DESCRIPTION
This commit makes xdcrDiffer use the most recent version of goxdcr and gomemcached at this time. This involves a few minor changes as well as additional mocks that need to take place in order to launch the difftool properly