### PR TITLE
Fixes #86: Consider SeqNoAdvanced to fix termination issues caused by unsubscrib…

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -102,7 +102,7 @@ const HttpsPrefix = "https://"
 const CouchbasePrefix = "couchbase://"
 const CouchbaseSecurePrefix = "couchbases://"
 
-var SetupTimeout = 5 * time.Second
+var SetupTimeout = 10 * time.Second
 
 const JSONDataType = 1
 
@@ -113,3 +113,5 @@ const (
 )
 
 var MutationDiffCompareType = []string{MutationCompareTypeMetadata, MutationCompareTypeBodyOnly, MutationCompareTypeBodyAndMeta}
+
+const Uint32MaxVal uint32 = 1<<32 - 1

--- a/dcp/DcpClient.go
+++ b/dcp/DcpClient.go
@@ -12,18 +12,19 @@ package dcp
 import (
 	"crypto/tls"
 	"fmt"
-	gocb "github.com/couchbase/gocb/v2"
-	gocbcore "github.com/couchbase/gocbcore/v9"
-	xdcrBase "github.com/couchbase/goxdcr/base"
-	xdcrLog "github.com/couchbase/goxdcr/log"
-	"github.com/couchbase/goxdcr/metadata"
-	xdcrUtils "github.com/couchbase/goxdcr/utils"
 	"math"
 	"sync"
 	"sync/atomic"
 	"time"
 	"xdcrDiffer/base"
 	"xdcrDiffer/utils"
+
+	gocb "github.com/couchbase/gocb/v2"
+	gocbcore "github.com/couchbase/gocbcore/v9"
+	xdcrBase "github.com/couchbase/goxdcr/base"
+	xdcrLog "github.com/couchbase/goxdcr/log"
+	"github.com/couchbase/goxdcr/metadata"
+	xdcrUtils "github.com/couchbase/goxdcr/utils"
 )
 
 type DcpClient struct {
@@ -294,7 +295,7 @@ func (c *DcpClient) initializeDcpHandlers() error {
 
 		dcpHandler, err := NewDcpHandler(c, c.dcpDriver.fileDir, i, vbList, c.dcpDriver.numberOfBins,
 			c.dcpDriver.dcpHandlerChanSize, c.dcpDriver.fdPool, c.dcpDriver.IncrementDocReceived,
-			c.dcpDriver.IncrementSysEventReceived, c.colMigrationFilters, c.utils, c.bufferCap,
+			c.dcpDriver.IncrementSysOrUnsubbedEventReceived, c.colMigrationFilters, c.utils, c.bufferCap,
 			c.migrationMapping)
 		if err != nil {
 			c.logger.Errorf("Error constructing dcp handler. err=%v\n", err)

--- a/dcp/DcpDriver.go
+++ b/dcp/DcpDriver.go
@@ -11,18 +11,19 @@ package dcp
 
 import (
 	"fmt"
-	gocbcore "github.com/couchbase/gocbcore/v9"
-	xdcrBase "github.com/couchbase/goxdcr/base"
-	xdcrParts "github.com/couchbase/goxdcr/base/filter"
-	xdcrLog "github.com/couchbase/goxdcr/log"
-	"github.com/couchbase/goxdcr/metadata"
-	xdcrUtils "github.com/couchbase/goxdcr/utils"
 	"sync"
 	"sync/atomic"
 	"time"
 	"xdcrDiffer/base"
 	fdp "xdcrDiffer/fileDescriptorPool"
 	"xdcrDiffer/utils"
+
+	gocbcore "github.com/couchbase/gocbcore/v9"
+	xdcrBase "github.com/couchbase/goxdcr/base"
+	xdcrParts "github.com/couchbase/goxdcr/base/filter"
+	xdcrLog "github.com/couchbase/goxdcr/log"
+	"github.com/couchbase/goxdcr/metadata"
+	xdcrUtils "github.com/couchbase/goxdcr/utils"
 )
 
 type DcpDriver struct {
@@ -63,8 +64,8 @@ type DcpDriver struct {
 	migrationMapping    metadata.CollectionNamespaceMapping
 
 	// various counters
-	totalNumReceivedFromDCP      uint64
-	totalSysEventReceivedFromDCP uint64
+	totalNumReceivedFromDCP                uint64
+	totalSysOrUnsubbedEventReceivedFromDCP uint64
 }
 
 type VBStateWithLock struct {
@@ -209,8 +210,8 @@ func (d *DcpDriver) Stop() error {
 		return nil
 	}
 
-	d.logger.Infof("Dcp driver %v stopping after receiving %v mutations (%v system events)\n", d.Name,
-		atomic.LoadUint64(&d.totalNumReceivedFromDCP), atomic.LoadUint64(&d.totalSysEventReceivedFromDCP))
+	d.logger.Infof("Dcp driver %v stopping after receiving %v mutations (%v system + unsubscribed events)\n", d.Name,
+		atomic.LoadUint64(&d.totalNumReceivedFromDCP), atomic.LoadUint64(&d.totalSysOrUnsubbedEventReceivedFromDCP))
 	defer d.logger.Infof("Dcp driver %v stopped\n", d.Name)
 	defer d.waitGroup.Done()
 
@@ -351,6 +352,6 @@ func (d *DcpDriver) IncrementDocReceived() {
 	atomic.AddUint64(&d.totalNumReceivedFromDCP, 1)
 }
 
-func (d *DcpDriver) IncrementSysEventReceived() {
-	atomic.AddUint64(&d.totalSysEventReceivedFromDCP, 1)
+func (d *DcpDriver) IncrementSysOrUnsubbedEventReceived() {
+	atomic.AddUint64(&d.totalSysOrUnsubbedEventReceivedFromDCP, 1)
 }

--- a/main.go
+++ b/main.go
@@ -1249,7 +1249,7 @@ func (difftool *xdcrDiffTool) populateDedupColIds(tgtColIds []uint32, tgtColIdDe
 		_, exists := tgtColIdDedupMap[tgtColId]
 		if !exists {
 			tgtColIdDedupMap[tgtColId] = true
-			difftool.tgtCollectionIds = append(difftool.tgtCollectionIds)
+			difftool.tgtCollectionIds = append(difftool.tgtCollectionIds, tgtColId)
 		}
 	}
 }


### PR DESCRIPTION
- Fixes issue: #86 

This issue is overcome by using DCP_SEQNO_ADV event streamed by the producer which will contain the mutations from a collection that the consumer is not subscribed to.