### PR TITLE
Fixes #90: Avoid using the agent after it is closed and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,16 @@ Usage of ./xdcrDiffer:
     	username for target cluster (default "Administrator")
   -verifyDiffKeys
     	whether to verify diff keys through aysnc Get on clusters (default true)
-  -mutationRetries
-        Additional number of times to retry to resolve the mutation differences
-  -mutationRetriesWaitSecs
-        Seconds to wait in between retries for mutation differences
+  -mutationRetries int
+      Additional number of times to retry to resolve the mutation differences
+  -mutationRetriesWaitSecs int
+      Seconds to wait in between retries for mutation differences
   -compareType string
-        What to compare during mutationDiff. Accepted values are: meta (default), body, both
+      What to compare during mutationDiff. Accepted values are: meta (default), body, both
+  -setupTimeout int
+      Common setup timeout duration in seconds. Default is 10 (seconds)
+  -debugMode
+      Set xdcrDiffer to DEBUG log level and also enable SDK (gocb) verbose logging.
 ```
 
 A few options worth noting:

--- a/base/constants.go
+++ b/base/constants.go
@@ -9,8 +9,6 @@
 
 package base
 
-import "time"
-
 const NumberOfVbuckets = 1024
 const DcpHandlerChanSize = 100000
 const FileNamePrefix = "diffTool"
@@ -102,7 +100,7 @@ const HttpsPrefix = "https://"
 const CouchbasePrefix = "couchbase://"
 const CouchbaseSecurePrefix = "couchbases://"
 
-var SetupTimeout = 10 * time.Second
+var SetupTimeoutSeconds int = 10
 
 const JSONDataType = 1
 

--- a/dcp/GocbcoreDCPAgent.go
+++ b/dcp/GocbcoreDCPAgent.go
@@ -3,11 +3,12 @@ package dcp
 import (
 	"crypto/x509"
 	"fmt"
+	"time"
+	"xdcrDiffer/base"
+
 	gocbcore "github.com/couchbase/gocbcore/v10"
 	memd "github.com/couchbase/gocbcore/v10/memd"
 	xdcrBase "github.com/couchbase/goxdcr/base"
-	"time"
-	"xdcrDiffer/base"
 )
 
 type GocbcoreDCPFeed struct {
@@ -117,7 +118,7 @@ func getAgentConfigs(authMech interface{}) (bool, func() *x509.CertPool, gocbcor
 func (f *GocbcoreDCPFeed) setupGocbcoreDCPAgent(config *gocbcore.DCPAgentConfig, flags memd.DcpOpenFlag, secure bool) (err error) {
 	f.dcpAgent, err = gocbcore.CreateDcpAgent(config, f.Name, flags)
 	if err != nil {
-		return err
+		return
 	}
 
 	options := gocbcore.WaitUntilReadyOptions{
@@ -137,11 +138,14 @@ func (f *GocbcoreDCPFeed) setupGocbcoreDCPAgent(config *gocbcore.DCPAgentConfig,
 	}
 
 	if err != nil {
-		go f.dcpAgent.Close()
+		errClosing := f.dcpAgent.Close()
+		err = fmt.Errorf("Closing GocbcoreDCPFeed.agent because of err=%v, error while closing=%v", err, errClosing)
+		return
 	}
 
 	if secure && !f.dcpAgent.IsSecure() {
-		return fmt.Errorf("%v requested secure but agent says not secure", f.Name)
+		err = fmt.Errorf("%v requested secure but agent says not secure", f.Name)
+		return
 	}
 
 	return
@@ -153,7 +157,7 @@ func NewGocbcoreDCPFeed(id string, servers []string, bucketName string, auth int
 			Name:         id,
 			Servers:      servers,
 			BucketName:   bucketName,
-			SetupTimeout: base.SetupTimeout,
+			SetupTimeout: time.Duration(base.SetupTimeoutSeconds) * time.Second,
 		},
 		dcpAgent: nil,
 	}

--- a/differ/GocbcoreAgent.go
+++ b/differ/GocbcoreAgent.go
@@ -3,12 +3,13 @@ package differ
 import (
 	"crypto/x509"
 	"fmt"
-	"github.com/couchbase/gocbcore/v10"
-	xdcrBase "github.com/couchbase/goxdcr/base"
-	"github.com/couchbase/goxdcr/metadata"
 	"reflect"
 	"time"
 	"xdcrDiffer/base"
+
+	"github.com/couchbase/gocbcore/v10"
+	xdcrBase "github.com/couchbase/goxdcr/base"
+	"github.com/couchbase/goxdcr/metadata"
 )
 
 type GocbcoreAgent struct {
@@ -105,7 +106,8 @@ func (a *GocbcoreAgent) setupGocbcoreAgent(config *gocbcore.AgentConfig) (err er
 	}
 
 	if err != nil {
-		go a.agent.Close()
+		errClosing := a.agent.Close()
+		err = fmt.Errorf("Closing GocbcoreAgent.agent because of err=%v, error while closing=%v", err, errClosing)
 	}
 	return
 }
@@ -136,7 +138,7 @@ func NewGocbcoreAgent(id string, servers []string, bucketName string, auth inter
 			Name:         id,
 			Servers:      servers,
 			BucketName:   bucketName,
-			SetupTimeout: 5 * time.Second,
+			SetupTimeout: time.Duration(base.SetupTimeoutSeconds) * time.Second,
 		},
 		agent: nil,
 	}


### PR DESCRIPTION
* Bail out if agent closes and do not proceed.
* 2 extra options added:
	* -l OR -sdkLogging to enable SDK (gocb) verbose logging
	* -w <int> OR -setupTimeout <int> to change the default common setup timeout duration (seconds)