### PR TITLE
Fixes #93: Combine SDK logger and XDCR debug logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ mutationDiff/
 source/
 target/
 xdcrDiffer
+go.mod
+go.sum
+xdcrDiffer.log

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ clean:
 deps:
 	$(GOMOD) init xdcrDiffer
 	$(GOGET) github.com/couchbase/gocbcore/v10
-	$(GOGET) github.com/couchbase/gocb
 	$(GOGET) github.com/couchbase/gocb/v2
 	$(GOGET) github.com/couchbaselabs/gojsonsm@v1.0.0
 	$(GOGET) github.com/couchbase/goxdcr@v7.6.0-1916

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 	"xdcrDiffer/filterPool"
 	"xdcrDiffer/utils"
 
-	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocb/v2"
 	xdcrBase "github.com/couchbase/goxdcr/base"
 	xdcrParts "github.com/couchbase/goxdcr/base/filter"
 	xdcrLog "github.com/couchbase/goxdcr/log"


### PR DESCRIPTION
The **main.go** file was setting the gocb's logger instead of gocb/v2's logger 
This change ensures that gocb/v2's logger is set
Additionally added a few files to .gitignore