### PR TITLE
Changes to the FileDiff section of Differ to support HLV comparison

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -77,8 +77,8 @@ const KeyLenVariable = 2
 const MigrationFilterLen = 2
 const xattrSizeLen = 4
 
-func GetFixedSizeMutationLen(keyLen int, xattrSize uint32, colMigrationFilterMatched []uint8) int {
-	return KeyLenVariable + keyLen + xattrSizeLen + int(xattrSize) + BodyLength + MigrationFilterLen + len(colMigrationFilterMatched)*2
+func GetFixedSizeMutationLen(keyLen int, size uint32, colMigrationFilterMatched []uint8) int {
+	return KeyLenVariable + keyLen + (2 * xattrSizeLen) + int(size) + BodyLength + MigrationFilterLen + len(colMigrationFilterMatched)*2
 }
 
 var VersionForRBACSupport = []int{5, 0}

--- a/base/constants.go
+++ b/base/constants.go
@@ -75,9 +75,10 @@ const ClusterRunMaxPortNo uint16 = 9007
 const BodyLength = 104
 const KeyLenVariable = 2
 const MigrationFilterLen = 2
+const xattrSizeLen = 4
 
-func GetFixedSizeMutationLen(keyLen int, colMigrationFilterMatched []uint8) int {
-	return KeyLenVariable + keyLen + BodyLength + MigrationFilterLen + len(colMigrationFilterMatched)*2
+func GetFixedSizeMutationLen(keyLen int, xattrSize uint32, colMigrationFilterMatched []uint8) int {
+	return KeyLenVariable + keyLen + xattrSizeLen + int(xattrSize) + BodyLength + MigrationFilterLen + len(colMigrationFilterMatched)*2
 }
 
 var VersionForRBACSupport = []int{5, 0}

--- a/base/constants.go
+++ b/base/constants.go
@@ -75,10 +75,21 @@ const ClusterRunMaxPortNo uint16 = 9007
 const BodyLength = 104
 const KeyLenVariable = 2
 const MigrationFilterLen = 2
-const xattrSizeLen = 4
+const xattrSizeLen = 4 // To store the size of the individual Xattr Key-Value pair
 
+const (
+	JsonBody     = "Body"
+	JsonMetadata = "Metadata"
+	Updated      = "Updated"
+)
+
+// This function is used to calculate the length of the byte array for serializing a mutation
+// @param keyLen denotes the length of the document key
+// @param size denoted the combined length of importCAS and HLV
+// @param colMigrationFilterMatched denotes the list of Migration Filters matched
 func GetFixedSizeMutationLen(keyLen int, size uint32, colMigrationFilterMatched []uint8) int {
-	return KeyLenVariable + keyLen + (2 * xattrSizeLen) + int(size) + BodyLength + MigrationFilterLen + len(colMigrationFilterMatched)*2
+	return KeyLenVariable + keyLen + (2 * xattrSizeLen) + int(size) + BodyLength + MigrationFilterLen + len(colMigrationFilterMatched)*2 // (2*xattrSizeLen - to store the size of importCAS and HLV)
+
 }
 
 var VersionForRBACSupport = []int{5, 0}

--- a/dcp/DcpClient.go
+++ b/dcp/DcpClient.go
@@ -296,7 +296,7 @@ func (c *DcpClient) initializeDcpHandlers() error {
 		dcpHandler, err := NewDcpHandler(c, c.dcpDriver.fileDir, i, vbList, c.dcpDriver.numberOfBins,
 			c.dcpDriver.dcpHandlerChanSize, c.dcpDriver.fdPool, c.dcpDriver.IncrementDocReceived,
 			c.dcpDriver.IncrementSysOrUnsubbedEventReceived, c.colMigrationFilters, c.utils, c.bufferCap,
-			c.migrationMapping, &xdcrBase.XattrIterator{})
+			c.migrationMapping)
 		if err != nil {
 			c.logger.Errorf("Error constructing dcp handler. err=%v\n", err)
 			return err

--- a/dcp/DcpClient.go
+++ b/dcp/DcpClient.go
@@ -296,7 +296,7 @@ func (c *DcpClient) initializeDcpHandlers() error {
 		dcpHandler, err := NewDcpHandler(c, c.dcpDriver.fileDir, i, vbList, c.dcpDriver.numberOfBins,
 			c.dcpDriver.dcpHandlerChanSize, c.dcpDriver.fdPool, c.dcpDriver.IncrementDocReceived,
 			c.dcpDriver.IncrementSysOrUnsubbedEventReceived, c.colMigrationFilters, c.utils, c.bufferCap,
-			c.migrationMapping)
+			c.migrationMapping, &xdcrBase.XattrIterator{})
 		if err != nil {
 			c.logger.Errorf("Error constructing dcp handler. err=%v\n", err)
 			return err

--- a/dcp/DcpDriver.go
+++ b/dcp/DcpDriver.go
@@ -68,6 +68,7 @@ type DcpDriver struct {
 	// various counters
 	totalNumReceivedFromDCP                uint64
 	totalSysOrUnsubbedEventReceivedFromDCP uint64
+	xattrKeysForNoCompare                  map[string]bool
 }
 
 type VBStateWithLock struct {
@@ -91,37 +92,38 @@ const (
 	DriverStateStopped DriverState = iota
 )
 
-func NewDcpDriver(logger *xdcrLog.CommonLogger, name, url, bucketName string, ref *metadata.RemoteClusterReference, fileDir, checkpointFileDir, oldCheckpointFileName, newCheckpointFileName string, numberOfClients, numberOfWorkers, numberOfBins, dcpHandlerChanSize int, bucketOpTimeout time.Duration, maxNumOfGetStatsRetry int, getStatsRetryInterval, getStatsMaxBackoff time.Duration, checkpointInterval int, errChan chan error, waitGroup *sync.WaitGroup, completeBySeqno bool, fdPool fdp.FdPoolIface, filter xdcrParts.Filter, capabilities metadata.Capability, collectionIds []uint32, colMigrationFilters []string, utils xdcrUtils.UtilsIface, bufferCap int, migrationMapping metadata.CollectionNamespaceMapping, mobileCompat int, expDelMode xdcrBase.FilterExpDelType) *DcpDriver {
+func NewDcpDriver(logger *xdcrLog.CommonLogger, name, url, bucketName string, ref *metadata.RemoteClusterReference, fileDir, checkpointFileDir, oldCheckpointFileName, newCheckpointFileName string, numberOfClients, numberOfWorkers, numberOfBins, dcpHandlerChanSize int, bucketOpTimeout time.Duration, maxNumOfGetStatsRetry int, getStatsRetryInterval, getStatsMaxBackoff time.Duration, checkpointInterval int, errChan chan error, waitGroup *sync.WaitGroup, completeBySeqno bool, fdPool fdp.FdPoolIface, filter xdcrParts.Filter, capabilities metadata.Capability, collectionIds []uint32, colMigrationFilters []string, utils xdcrUtils.UtilsIface, bufferCap int, migrationMapping metadata.CollectionNamespaceMapping, mobileCompat int, expDelMode xdcrBase.FilterExpDelType, xattrKeysForNoCompare map[string]bool) *DcpDriver {
 	dcpDriver := &DcpDriver{
-		Name:                name,
-		url:                 url,
-		bucketName:          bucketName,
-		ref:                 ref,
-		fileDir:             fileDir,
-		numberOfClients:     numberOfClients,
-		numberOfWorkers:     numberOfWorkers,
-		numberOfBins:        numberOfBins,
-		dcpHandlerChanSize:  dcpHandlerChanSize,
-		completeBySeqno:     completeBySeqno,
-		errChan:             errChan,
-		waitGroup:           waitGroup,
-		clients:             make([]*DcpClient, numberOfClients),
-		childWaitGroup:      &sync.WaitGroup{},
-		vbStateMap:          make(map[uint16]*VBStateWithLock),
-		fdPool:              fdPool,
-		state:               DriverStateNew,
-		finChan:             make(chan bool),
-		startVbtsDoneChan:   make(chan bool),
-		logger:              logger,
-		filter:              filter,
-		capabilities:        capabilities,
-		collectionIDs:       collectionIds,
-		colMigrationFilters: colMigrationFilters,
-		utils:               utils,
-		bufferCapacity:      bufferCap,
-		migrationMapping:    migrationMapping,
-		mobileCompatible:    mobileCompat,
-		expDelMode:          expDelMode,
+		Name:                  name,
+		url:                   url,
+		bucketName:            bucketName,
+		ref:                   ref,
+		fileDir:               fileDir,
+		numberOfClients:       numberOfClients,
+		numberOfWorkers:       numberOfWorkers,
+		numberOfBins:          numberOfBins,
+		dcpHandlerChanSize:    dcpHandlerChanSize,
+		completeBySeqno:       completeBySeqno,
+		errChan:               errChan,
+		waitGroup:             waitGroup,
+		clients:               make([]*DcpClient, numberOfClients),
+		childWaitGroup:        &sync.WaitGroup{},
+		vbStateMap:            make(map[uint16]*VBStateWithLock),
+		fdPool:                fdPool,
+		state:                 DriverStateNew,
+		finChan:               make(chan bool),
+		startVbtsDoneChan:     make(chan bool),
+		logger:                logger,
+		filter:                filter,
+		capabilities:          capabilities,
+		collectionIDs:         collectionIds,
+		colMigrationFilters:   colMigrationFilters,
+		utils:                 utils,
+		bufferCapacity:        bufferCap,
+		migrationMapping:      migrationMapping,
+		mobileCompatible:      mobileCompat,
+		expDelMode:            expDelMode,
+		xattrKeysForNoCompare: xattrKeysForNoCompare,
 	}
 
 	var vbno uint16

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -233,18 +233,18 @@ func comparePv(Pv1 hlv.VersionsMap, Pv2 hlv.VersionsMap, cas1 uint64, cas2 uint6
 			}
 		}
 	} else { // Unequal length implies that the PVs are pruned
-		sourcePruningWindow := sourcePruningWindow.get()
-		targetPruningWindow := targetPruningWindow.get()
+		srcPruningWindow := sourcePruningWindow.get()
+		tgtPruningWindow := targetPruningWindow.get()
 		var pruningWindow time.Duration
 		iteratePv := Pv1
 		otherPv := Pv2
 		cas := cas1
-		pruningWindow = sourcePruningWindow
+		pruningWindow = srcPruningWindow
 		if len(Pv2) > len(Pv1) {
 			iteratePv = Pv2
 			otherPv = Pv1
 			cas = cas2
-			pruningWindow = targetPruningWindow
+			pruningWindow = tgtPruningWindow
 		}
 		for key, value1 := range iteratePv {
 			value2, ok := otherPv[key]
@@ -457,7 +457,7 @@ func getOneEntry(readOp fdp.FileOp, bucketUUID hlv.DocumentSourceId) (*oneEntry,
 		return nil, fmt.Errorf("Unable to read importCas, bytes read: %v, err: %v", bytesRead, err)
 	}
 	if len(importBytes) != 0 {
-		entry.ImportCas, err = xdcrBase.HexLittleEndianToUint64(importBytes)
+		entry.ImportCas, err = xdcrBase.HexLittleEndianToUint64(importBytes[1 : importSize-1])
 		if err != nil {
 			return nil, fmt.Errorf("Unable to convert ImportCas from hexadecimal bytes to uint64, err: %v", err)
 		}

--- a/differ/differDriver.go
+++ b/differ/differDriver.go
@@ -243,7 +243,7 @@ type DifferDriver struct {
 	logger            *xdcrLog.CommonLogger
 }
 
-func NewDifferDriver(sourceFileDir, targetFileDir, diffFileDir, diffKeysFileName, sourceBucketUUID, targetBucketUUID string, numberOfWorkers, numberOfBins, numberOfFds int, collectionMapping map[uint32][]uint32, colFilterStrings []string, colFilterTgtIds []uint32, bucketTopologySvc service_def.BucketTopologySvc, specifiedSpec *metadata.ReplicationSpecification, logger *xdcrLog.CommonLogger) *DifferDriver {
+func NewDifferDriver(sourceFileDir, targetFileDir, diffFileDir, diffKeysFileName string, numberOfWorkers, numberOfBins, numberOfFds int, collectionMapping map[uint32][]uint32, colFilterStrings []string, colFilterTgtIds []uint32, sourceBucketUUID, targetBucketUUID string, bucketTopologySvc service_def.BucketTopologySvc, specifiedSpec *metadata.ReplicationSpecification, logger *xdcrLog.CommonLogger) *DifferDriver {
 	var fdPool *fdp.FdPool
 	if numberOfFds > 0 {
 		fdPool = fdp.NewFileDescriptorPool(numberOfFds)
@@ -254,8 +254,6 @@ func NewDifferDriver(sourceFileDir, targetFileDir, diffFileDir, diffKeysFileName
 		targetFileDir:     targetFileDir,
 		diffFileDir:       diffFileDir,
 		diffKeysFileName:  diffKeysFileName,
-		sourceBucketUUID:  sourceBucketUUID,
-		targetBucketUUID:  targetBucketUUID,
 		numberOfWorkers:   numberOfWorkers,
 		numberOfBins:      numberOfBins,
 		waitGroup:         &sync.WaitGroup{},
@@ -272,6 +270,8 @@ func NewDifferDriver(sourceFileDir, targetFileDir, diffFileDir, diffKeysFileName
 		TgtVbItemCntMap:   make(map[uint16]int),
 		MapLock:           &sync.RWMutex{},
 		DuplicatedHint:    DuplicatedHintMap{},
+		sourceBucketUUID:  sourceBucketUUID,
+		targetBucketUUID:  targetBucketUUID,
 		bucketTopologySvc: bucketTopologySvc,
 		specifiedSpec:     specifiedSpec,
 		logger:            logger,

--- a/main.go
+++ b/main.go
@@ -350,6 +350,7 @@ func NewDiffTool(legacyMode bool) (*xdcrDiffTool, error) {
 			difftool.xattrKeysForNoCompare[fileScanner.Text()] = true
 		}
 	}
+	// HLV and ImportCas needs to be stripped from the Xattrs
 	difftool.xattrKeysForNoCompare[xdcrBase.XATTR_HLV] = true
 	difftool.xattrKeysForNoCompare[xdcrBase.XATTR_IMPORTCAS] = true
 	logCtx := xdcrLog.DefaultLoggerContext
@@ -786,8 +787,8 @@ func (difftool *xdcrDiffTool) diffDataFiles() error {
 	}
 
 	difftoolDriver := differ.NewDifferDriver(options.sourceFileDir, options.targetFileDir, options.fileDifferDir,
-		base.DiffKeysFileName, difftool.specifiedSpec.SourceBucketUUID, difftool.specifiedSpec.TargetBucketUUID, int(options.numberOfWorkersForFileDiffer), int(options.numberOfBins),
-		int(options.numberOfFileDesc), difftool.srcToTgtColIdsMap, difftool.colFilterOrderedKeys, difftool.colFilterOrderedTargetColId, difftool.bucketTopologySvc, difftool.specifiedSpec, difftool.logger)
+		base.DiffKeysFileName, int(options.numberOfWorkersForFileDiffer), int(options.numberOfBins),
+		int(options.numberOfFileDesc), difftool.srcToTgtColIdsMap, difftool.colFilterOrderedKeys, difftool.colFilterOrderedTargetColId, difftool.specifiedSpec.SourceBucketUUID, difftool.specifiedSpec.TargetBucketUUID, difftool.bucketTopologySvc, difftool.specifiedSpec, difftool.logger)
 	err = difftoolDriver.Run()
 	if err != nil {
 		difftool.logger.Errorf("Error from diffDataFiles = %v\n", err)

--- a/main.go
+++ b/main.go
@@ -338,15 +338,17 @@ func NewDiffTool(legacyMode bool) (*xdcrDiffTool, error) {
 		colFilterToTgtColIdsMap: map[string][]uint32{},
 		xattrKeysForNoCompare:   map[string]bool{},
 	}
-	readFile, er := os.Open(options.fileContaingXattrKeysForNoComapre)
-	if er != nil {
-		fmt.Printf("Error in reading the file %v. err=%v\n", options.fileContaingXattrKeysForNoComapre, err)
-		return nil, er
-	}
-	fileScanner := bufio.NewScanner(readFile)
-	fileScanner.Split(bufio.ScanLines)
-	for fileScanner.Scan() {
-		difftool.xattrKeysForNoCompare[fileScanner.Text()] = true
+	if options.fileContaingXattrKeysForNoComapre != "" {
+		readFile, er := os.Open(options.fileContaingXattrKeysForNoComapre)
+		if er != nil {
+			fmt.Printf("Error in reading the file %v. err=%v\n", options.fileContaingXattrKeysForNoComapre, err)
+			return nil, er
+		}
+		fileScanner := bufio.NewScanner(readFile)
+		fileScanner.Split(bufio.ScanLines)
+		for fileScanner.Scan() {
+			difftool.xattrKeysForNoCompare[fileScanner.Text()] = true
+		}
 	}
 	difftool.xattrKeysForNoCompare[xdcrBase.XATTR_HLV] = true
 	difftool.xattrKeysForNoCompare[xdcrBase.XATTR_IMPORTCAS] = true

--- a/runDiffer.sh
+++ b/runDiffer.sh
@@ -59,7 +59,7 @@ function killBgTail {
 	fi
 }
 
-while getopts ":h:p:u:r:s:t:n:q:v:cbm:ew:d" opt; do
+while getopts ":h:p:u:r:s:t:n:q:v:cbm:ew:d:x:" opt; do
 	case ${opt} in
 	u)
 		username=$OPTARG
@@ -105,6 +105,9 @@ while getopts ":h:p:u:r:s:t:n:q:v:cbm:ew:d" opt; do
 		;;
 	w)
 		setupTimeout=$OPTARG
+		;;
+	x)
+		xattrsNoCompare=$OPTARG
 		;;
 	\?)
 		echo "Invalid option: $OPTARG" 1>&2
@@ -210,6 +213,10 @@ fi
 if [[ ! -z "$debugMode" ]]; then
 	execString="${execString} -debugMode"
 	execString="${execString} $debugMode"
+fi
+if [[ ! -z "$xattrsNoCompare" ]]; then
+	execString="${execString} -xattrsNoCompare"
+	execString="${execString} $xattrsNoCompare"
 fi
 
 # Execute the differ in background and watch the pid to be finished


### PR DESCRIPTION
The changes include the following
1) Separating the Xattr section from the body 
2) Writing the Xattrs and the body independently to the file
3) Reading the Xattrs and the body seperatly
4) Creating an Iterator over the Xattrs to fetch the HLV
5) Creating the HLV struct and storing it as a part of the oneEntry struct that contains all the necessary fields for comparison of docs
6) adding the compareHlv function that does the HlvComparison 