### PR TITLE
Enable TLS connection

### DIFF
--- a/base/gocbcoreCommon.go
+++ b/base/gocbcoreCommon.go
@@ -25,6 +25,7 @@ type PasswordAuth struct {
 type CertificateAuth struct {
 	PasswordAuth
 	CertificateBytes []byte
+	PrivateKey       []byte
 }
 
 func (c *CertificateAuth) SupportsTLS() bool {
@@ -36,7 +37,7 @@ func (c *CertificateAuth) SupportsNonTLS() bool {
 }
 
 func (c *CertificateAuth) Certificate(req gocbcore.AuthCertRequest) (*tls.Certificate, error) {
-	return &tls.Certificate{Certificate: [][]byte{c.CertificateBytes}}, nil
+	return &tls.Certificate{Certificate: [][]byte{c.CertificateBytes, c.PrivateKey}}, nil
 }
 
 func (c *CertificateAuth) Credentials(req gocbcore.AuthCredsRequest) ([]gocbcore.UserPassPair, error) {

--- a/dcp/CheckpointManager.go
+++ b/dcp/CheckpointManager.go
@@ -608,7 +608,7 @@ func (cm *CheckpointManager) getSnapshot(vbno uint16) (startSeqno, endSeqno uint
 }
 
 func (cm *CheckpointManager) initializeBucket() (err error) {
-	auth, bucketConnStr, useTLS, err := initializeBucketWithSecurity(cm.dcpDriver, cm.kvVbMap, cm.kvSSLPortMap, false)
+	auth, bucketConnStr, err := initializeBucketWithSecurity(cm.dcpDriver, cm.kvVbMap, cm.kvSSLPortMap, false)
 	if err != nil {
 		return
 	}

--- a/dcp/GocbcoreDCPAgent.go
+++ b/dcp/GocbcoreDCPAgent.go
@@ -94,7 +94,7 @@ func getAgentConfigs(authMech interface{}, ref *metadata.RemoteClusterReference)
 		// https means we need to at a min return a root CA
 		ok := certPool.AppendCertsFromPEM(ref.Certificate())
 		if !ok {
-			return false, nil, nil, fmt.Errorf("Invalid rootCA")
+			return false, nil, nil, fmt.Errorf("Invalid rootCA %s", ref.Certificate())
 		}
 		useTLS = true
 	}

--- a/dcp/GocbcoreDCPAgent.go
+++ b/dcp/GocbcoreDCPAgent.go
@@ -3,6 +3,8 @@ package dcp
 import (
 	"crypto/x509"
 	"fmt"
+	"github.com/couchbase/goxdcr/metadata"
+	"reflect"
 	"time"
 	"xdcrDiffer/base"
 
@@ -16,8 +18,8 @@ type GocbcoreDCPFeed struct {
 	dcpAgent *gocbcore.DCPAgent
 }
 
-func (f *GocbcoreDCPFeed) setupDCPAgent(auth interface{}, collections bool) error {
-	agentConfig, shouldBeSecure, err := f.setupDCPAgentConfig(auth, collections)
+func (f *GocbcoreDCPFeed) setupDCPAgent(auth interface{}, collections bool, ref *metadata.RemoteClusterReference) error {
+	agentConfig, shouldBeSecure, err := f.setupDCPAgentConfig(auth, collections, ref)
 	if err != nil {
 		return err
 	}
@@ -64,10 +66,13 @@ func NewDCPFeedParams() *DCPFeedParams {
 	return &DCPFeedParams{IncludeXAttrs: true}
 }
 
-func (f *GocbcoreDCPFeed) setupDCPAgentConfig(authMech interface{}, collections bool) (*gocbcore.DCPAgentConfig, bool, error) {
-	useTLS, x509Provider, auth, err := getAgentConfigs(authMech)
+func (f *GocbcoreDCPFeed) setupDCPAgentConfig(authMech interface{}, collections bool, ref *metadata.RemoteClusterReference) (*gocbcore.DCPAgentConfig, bool, error) {
+	useTLS, x509Provider, auth, err := getAgentConfigs(authMech, ref)
 	if err != nil {
 		return nil, false, err
+	}
+	if auth == nil {
+		panic("Nil auth")
 	}
 	return &gocbcore.DCPAgentConfig{
 		UserAgent:         f.Name,
@@ -81,11 +86,22 @@ func (f *GocbcoreDCPFeed) setupDCPAgentConfig(authMech interface{}, collections 
 	}, useTLS, nil
 }
 
-func getAgentConfigs(authMech interface{}) (bool, func() *x509.CertPool, gocbcore.AuthProvider, error) {
+func getAgentConfigs(authMech interface{}, ref *metadata.RemoteClusterReference) (bool, func() *x509.CertPool, gocbcore.AuthProvider, error) {
+	certPool := x509.NewCertPool()
 	var useTLS bool
-	x509Provider := func() *x509.CertPool {
-		return nil
+
+	if ref.HttpAuthMech() == xdcrBase.HttpAuthMechHttps {
+		// https means we need to at a min return a root CA
+		ok := certPool.AppendCertsFromPEM(ref.Certificate())
+		if !ok {
+			return false, nil, nil, fmt.Errorf("Invalid rootCA")
+		}
+		useTLS = true
 	}
+	x509Provider := func() *x509.CertPool {
+		return certPool
+	}
+
 	var auth gocbcore.AuthProvider
 	if pw, ok := authMech.(*base.PasswordAuth); ok {
 		auth = gocbcore.PasswordAuthProvider{
@@ -95,15 +111,16 @@ func getAgentConfigs(authMech interface{}) (bool, func() *x509.CertPool, gocbcor
 	} else if cert, ok := authMech.(*base.CertificateAuth); ok {
 		// The base.CertificateAuth should implement the methods for a provider
 		auth = cert
-		useTLS = true
-		certPool := x509.NewCertPool()
-		ok := certPool.AppendCertsFromPEM(cert.CertificateBytes)
+		ok = certPool.AppendCertsFromPEM(cert.CertificateBytes)
 		if !ok {
-			return false, nil, nil, xdcrBase.InvalidCerfiticateError
+			return useTLS, nil, nil, fmt.Errorf("Invalid client cert %s", cert.CertificateBytes)
 		}
-		x509Provider = func() *x509.CertPool {
-			return certPool
+		ok = certPool.AppendCertsFromPEM(cert.PrivateKey)
+		if !ok {
+			return useTLS, nil, nil, fmt.Errorf("Invalid client key %s", cert.PrivateKey)
 		}
+	} else {
+		panic(fmt.Sprintf("unknown authmech: %v", reflect.TypeOf(authMech)))
 	}
 	return useTLS, x509Provider, auth, nil
 }
@@ -144,7 +161,7 @@ func (f *GocbcoreDCPFeed) setupGocbcoreDCPAgent(config *gocbcore.DCPAgentConfig,
 	return
 }
 
-func NewGocbcoreDCPFeed(id string, servers []string, bucketName string, auth interface{}, collections bool) (*GocbcoreDCPFeed, error) {
+func NewGocbcoreDCPFeed(id string, servers []string, bucketName string, auth interface{}, collections bool, ref *metadata.RemoteClusterReference) (*GocbcoreDCPFeed, error) {
 	gocbcoreDcpFeed := &GocbcoreDCPFeed{
 		GocbcoreAgentCommon: base.GocbcoreAgentCommon{
 			Name:         id,
@@ -155,6 +172,10 @@ func NewGocbcoreDCPFeed(id string, servers []string, bucketName string, auth int
 		dcpAgent: nil,
 	}
 
-	err := gocbcoreDcpFeed.setupDCPAgent(auth, collections)
+	if auth == nil {
+		panic("nil auth")
+	}
+
+	err := gocbcoreDcpFeed.setupDCPAgent(auth, collections, ref)
 	return gocbcoreDcpFeed, err
 }

--- a/differ/GocbcoreAgent.go
+++ b/differ/GocbcoreAgent.go
@@ -64,11 +64,11 @@ func (a *GocbcoreAgent) setupAgentConfig(authIn interface{}, capability metadata
 		auth = certAuth
 		ok = certPool.AppendCertsFromPEM(certAuth.CertificateBytes)
 		if !ok {
-			return nil, fmt.Errorf("Invalid clientCert1")
+			return nil, fmt.Errorf("setupAgent invalid clientCert %s", certAuth.CertificateBytes)
 		}
 		ok = certPool.AppendCertsFromPEM(certAuth.PrivateKey)
 		if !ok {
-			return nil, fmt.Errorf("Invalid clientKey1")
+			return nil, fmt.Errorf("setupAgent invalid clientKey %s", certAuth.PrivateKey)
 		}
 	} else {
 		panic(fmt.Sprintf("Unknown type: %v\n", reflect.TypeOf(authIn)))

--- a/differ/GocbcoreAgent.go
+++ b/differ/GocbcoreAgent.go
@@ -17,8 +17,8 @@ type GocbcoreAgent struct {
 	agent *gocbcore.Agent
 }
 
-func (a *GocbcoreAgent) setupAgent(auth interface{}, batchSize int, capability metadata.Capability) error {
-	agentConfig, err := a.setupAgentConfig(auth, capability)
+func (a *GocbcoreAgent) setupAgent(auth interface{}, batchSize int, capability metadata.Capability, reference *metadata.RemoteClusterReference) error {
+	agentConfig, err := a.setupAgentConfig(auth, capability, reference)
 	if err != nil {
 		return err
 	}
@@ -34,32 +34,44 @@ func (a *GocbcoreAgent) setupAgent(auth interface{}, batchSize int, capability m
 	return a.setupGocbcoreAgent(agentConfig)
 }
 
-func (a *GocbcoreAgent) setupAgentConfig(authIn interface{}, capability metadata.Capability) (*gocbcore.AgentConfig, error) {
+func (a *GocbcoreAgent) setupAgentConfig(authIn interface{}, capability metadata.Capability, reference *metadata.RemoteClusterReference) (*gocbcore.AgentConfig, error) {
 	var auth gocbcore.AuthProvider
 	var useTLS bool
-	x509Provider := func() *x509.CertPool {
-		return nil
+	certPool := x509.NewCertPool()
+
+	if authIn == nil {
+		panic("authIn is nil")
 	}
-	if authIn != nil {
-		if pwAuth, ok := authIn.(*base.PasswordAuth); ok {
-			auth = gocbcore.PasswordAuthProvider{
-				Username: pwAuth.Username,
-				Password: pwAuth.Password,
-			}
-		} else if certAuth, ok := authIn.(*base.CertificateAuth); ok {
-			useTLS = true
-			auth = certAuth
-			certPool := x509.NewCertPool()
-			ok := certPool.AppendCertsFromPEM(certAuth.CertificateBytes)
-			if !ok {
-				return nil, xdcrBase.InvalidCerfiticateError
-			}
-			x509Provider = func() *x509.CertPool {
-				return certPool
-			}
-		} else {
-			panic(fmt.Sprintf("Unknown type: %v\n", reflect.TypeOf(authIn)))
+
+	if reference.HttpAuthMech() == xdcrBase.HttpAuthMechHttps {
+		useTLS = true
+		ok := certPool.AppendCertsFromPEM(reference.Certificate())
+		if !ok {
+			return nil, fmt.Errorf("Invalid rootCA from gocbcoreagent")
 		}
+	}
+	x509Provider := func() *x509.CertPool {
+		return certPool
+	}
+
+	if pwAuth, ok := authIn.(*base.PasswordAuth); ok {
+		auth = gocbcore.PasswordAuthProvider{
+			Username: pwAuth.Username,
+			Password: pwAuth.Password,
+		}
+	} else if certAuth, ok := authIn.(*base.CertificateAuth); ok {
+		useTLS = true
+		auth = certAuth
+		ok = certPool.AppendCertsFromPEM(certAuth.CertificateBytes)
+		if !ok {
+			return nil, fmt.Errorf("Invalid clientCert1")
+		}
+		ok = certPool.AppendCertsFromPEM(certAuth.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("Invalid clientKey1")
+		}
+	} else {
+		panic(fmt.Sprintf("Unknown type: %v\n", reflect.TypeOf(authIn)))
 	}
 
 	return &gocbcore.AgentConfig{
@@ -124,7 +136,7 @@ func (a *GocbcoreAgent) GetMeta(key string, callbackFunc func(result *gocbcore.G
 	return err
 }
 
-func NewGocbcoreAgent(id string, servers []string, bucketName string, auth interface{}, batchSize int, capability metadata.Capability) (*GocbcoreAgent, error) {
+func NewGocbcoreAgent(id string, servers []string, bucketName string, auth interface{}, batchSize int, capability metadata.Capability, reference *metadata.RemoteClusterReference) (*GocbcoreAgent, error) {
 	gocbcoreAgent := &GocbcoreAgent{
 		GocbcoreAgentCommon: base.GocbcoreAgentCommon{
 			Name:         id,
@@ -135,6 +147,6 @@ func NewGocbcoreAgent(id string, servers []string, bucketName string, auth inter
 		agent: nil,
 	}
 
-	err := gocbcoreAgent.setupAgent(auth, batchSize, capability)
+	err := gocbcoreAgent.setupAgent(auth, batchSize, capability, reference)
 	return gocbcoreAgent, err
 }

--- a/differ/mutationDiffer.go
+++ b/differ/mutationDiffer.go
@@ -1093,7 +1093,8 @@ func (d *MutationDiffer) openBucket(bucketName string, reference *metadata.Remot
 
 	if !source && len(reference.ClientKey()) > 0 && len(reference.ClientCertificate()) > 0 {
 		auth = &base.CertificateAuth{
-			PasswordAuth:     pwAuth,
+			// client cert auth requires no password
+			PasswordAuth:     base.PasswordAuth{},
 			CertificateBytes: reference.ClientCertificate(),
 			PrivateKey:       reference.ClientKey(),
 		}

--- a/differ/mutationDiffer.go
+++ b/differ/mutationDiffer.go
@@ -1089,11 +1089,19 @@ func (d *MutationDiffer) openBucket(bucketName string, reference *metadata.Remot
 		return err
 	}
 
-	if reference.HttpAuthMech() == xdcrBase.HttpAuthMechHttps {
+	useSecurePrefix := reference.HttpAuthMech() == xdcrBase.HttpAuthMechHttps
+
+	if !source && len(reference.ClientKey()) > 0 && len(reference.ClientCertificate()) > 0 {
 		auth = &base.CertificateAuth{
 			PasswordAuth:     pwAuth,
-			CertificateBytes: reference.Certificate(),
+			CertificateBytes: reference.ClientCertificate(),
+			PrivateKey:       reference.ClientKey(),
 		}
+	} else {
+		auth = &pwAuth
+	}
+
+	if useSecurePrefix {
 		err = d.initializeKvSSLMap(source)
 		if err != nil {
 			return err
@@ -1121,11 +1129,10 @@ func (d *MutationDiffer) openBucket(bucketName string, reference *metadata.Remot
 		connStr = xdcrBase.GetHostAddr(xdcrBase.GetHostName(connStr), sslPort)
 		base.TagCouchbaseSecurePrefix(&connStr)
 	} else {
-		auth = &pwAuth
 		base.TagHttpPrefix(&connStr)
 	}
 
-	agent, err := NewGocbcoreAgent(name, []string{connStr}, bucketName, auth, d.batchSize, capability)
+	agent, err := NewGocbcoreAgent(name, []string{connStr}, bucketName, auth, d.batchSize, capability, reference)
 
 	if source {
 		d.sourceBucket = agent


### PR DESCRIPTION
Some of the earlier TLS implementation were not necessarily correct and thus led to obscure error messages.
This PR re-evaluates how TLS should be used of either username/pw or clientcert/key in the context of gocbcore.

Verification has been done on a Linux VMs environment, with the target memcacheds receiving traffic from the differ via port 11207.

```
2024-05-13T04:14:33.442455+00:00 INFO 77: HELO [{"a":"gocbcore/v9.1.10 target_0","i":"49e7ec9dd56cbb43/8570e4f34ce4cb64"}] XATTR, XERROR, Select bucket, JSON, AltRequestSupport, SyncReplication, Collections, SubdocCreateAsDeleted, SubdocReplaceBodyWithXattr [ {"ip":"192.168.56.5","port":44896} - {"ip":"192.168.56.3","port":11207} (not authenticated) ]
2024-05-13T04:14:33.444533+00:00 INFO 77: Client {"ip":"192.168.56.5","port":44896} authenticated as <ud>Administrator</ud>
2024-05-13T04:14:33.446688+00:00 INFO 77: DCP connection opened successfully. PRODUCER, INCLUDE_XATTRS [ {"ip":"192.168.56.5","port":44896} - {"ip":"192.168.56.3","port":11207} (<ud>Administrator</ud>) ]
2024-05-13T04:14:33.451411+00:00 INFO 77 - using DCP buffer size of 20971520
2024-05-13T04:14:33.613763+00:00 INFO 77: (B2) DCP (Producer) eq_dcpq:target_0 - (vb:410) Creating stream with start seqno 0 and end seqno 18446744073709551615; requested end seqno was 18446744073709551615, snapshot:{0,0} collections-filter-size:0 sid:none
2024-05-13T04:14:33.614326+00:00 INFO 77: (B2) DCP (Producer) eq_dcpq:target_0 - (vb:410) ActiveStream::scheduleBackfill_UNLOCKED register cursor with name "eq_dcpq:target_0" lastProcessedSeqno:0, result{tryBackfill:true, op:empty, seqno:16, nextSeqno:16}
2024-05-13T04:14:33.614642+00:00 INFO 77: (B2) DCP (Producer) eq_dcpq:target_0 - (vb:410) Scheduling backfill from 1 to 15, uid:1, reschedule flag : False
```

With respect to the source, it may not be fully using 11207 but we can tackle that later.

I have not successfully verified clientkey/cert connection yet, but that could be done later.